### PR TITLE
Add support for multiple script files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also find instructions on how to use the Prefiller plugin on the [Gradle
 
 #### Write your setup script
 
-Next you need to create a `.sql` script with all your setup statements. Simply place this file somewhere in your project. Prefiller will use this file to populate the database, so make sure the statements are valid and match the database schema.
+Next you need to create a `.sql` script with all your setup statements. Simply place this file somewhere in your project. Prefiller will use this file to populate the database, so make sure the statements are valid and match the database schema. You can also supply multiple `.sql` files if you wish.
 
 ```sql
 -- src/main/sql/setup.sql
@@ -69,7 +69,7 @@ Lastly, you have to configure the Prefiller plugin in your `build.gradle` by lin
 prefiller {
     database("people") {
         classname.set("com.example.PeopleDatabase")
-        script.set(layout.projectDirectory.file("src/main/sql/setup.sql"))
+        scripts.from(file("src/main/sql/setup.sql"))
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ First you need to add the Prefiller plugin to your project by adding this block 
 
 ```groovy
 plugins {
-    id "io.github.simonschiller.prefiller" version "1.3.0"
+    id "io.github.simonschiller.prefiller" version "1.4.0"
 }
 ```
 
@@ -36,7 +36,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "io.github.simonschiller:prefiller:1.3.0"
+        classpath "io.github.simonschiller:prefiller:1.4.0"
     }
 }
 ```

--- a/prefiller/build.gradle.kts
+++ b/prefiller/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 group = "io.github.simonschiller"
-version = "1.3.0" // Also update the version in the README
+version = "1.4.0" // Also update the version in the README
 
 repositories {
     google()

--- a/prefiller/src/main/kotlin/io/github/simonschiller/prefiller/DatabaseConfig.kt
+++ b/prefiller/src/main/kotlin/io/github/simonschiller/prefiller/DatabaseConfig.kt
@@ -25,6 +25,7 @@ import com.android.build.gradle.api.BaseVariant
 import com.google.devtools.ksp.gradle.KspExtension
 import io.github.simonschiller.prefiller.internal.util.Version
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -35,6 +36,9 @@ import java.util.Locale
 
 class DatabaseConfig internal constructor(val name: String, objects: ObjectFactory) {
     val classname: Property<String> = objects.property(String::class.java)
+    val scripts: ConfigurableFileCollection = objects.fileCollection()
+
+    @Deprecated("Use the new scripts property instead.", ReplaceWith("scripts"))
     val script: RegularFileProperty = objects.fileProperty()
 
     internal fun registerTasks(project: Project, variant: BaseVariant) {
@@ -44,10 +48,6 @@ class DatabaseConfig internal constructor(val name: String, objects: ObjectFacto
 
         // Validate configuration
         val classname = classname.orNull ?: error("No classname configured for database $name")
-        val script = script.asFile.orNull ?: error("No script configured for database $name")
-        check(script.isFile && script.canRead() && script.extension.equals("sql", ignoreCase = true)) {
-            "Cannot locate script at $script, make sure you specify a valid .sql file"
-        }
 
         val databaseDir = project.layout.buildDirectory.dir("$FD_GENERATED/prefiller/${variant.name}")
         val databaseFile = databaseDir.map { dir -> dir.file("$name.db") }
@@ -56,8 +56,15 @@ class DatabaseConfig internal constructor(val name: String, objects: ObjectFacto
         // Register task for database
         val task = project.tasks.register(taskName, PrefillerTask::class.java) { prefillerTask ->
             prefillerTask.description = "Generates and pre-fills ${this@DatabaseConfig.name} database for variant ${variant.name}"
-            prefillerTask.scriptFile.set(script)
             prefillerTask.generatedDatabaseFile.set(databaseFile)
+
+            // Compatibility until the script property has been fully removed
+            if (script.isPresent) {
+                project.logger.warn("Deprecated 'script' property was used, please use 'scripts' instead.")
+                prefillerTask.scriptFiles.setFrom(script)
+            } else {
+                prefillerTask.scriptFiles.setFrom(scripts)
+            }
 
             // On Gradle versions earlier than 6.3, we have to resolve the path manually due to a bug
             val schemaDir = schemaLocation.map { parentDir ->

--- a/prefiller/src/main/kotlin/io/github/simonschiller/prefiller/PrefillerTask.kt
+++ b/prefiller/src/main/kotlin/io/github/simonschiller/prefiller/PrefillerTask.kt
@@ -20,11 +20,12 @@ import io.github.simonschiller.prefiller.internal.DatabasePopulator
 import io.github.simonschiller.prefiller.internal.RoomSchemaLocator
 import io.github.simonschiller.prefiller.internal.parser.StatementParserFactory
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -37,9 +38,9 @@ open class PrefillerTask : DefaultTask() {
     @PathSensitive(PathSensitivity.RELATIVE)
     val schemaDirectory: DirectoryProperty = project.objects.directoryProperty()
 
-    @InputFile
+    @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    val scriptFile: RegularFileProperty = project.objects.fileProperty()
+    val scriptFiles: ConfigurableFileCollection = project.objects.fileCollection()
 
     @OutputFile
     val generatedDatabaseFile: RegularFileProperty = project.objects.fileProperty()
@@ -54,7 +55,7 @@ open class PrefillerTask : DefaultTask() {
         // Parse the statements
         val parserFactory = StatementParserFactory()
         val setupStatements = parserFactory.createParser(schemaFile).parse()
-        val scriptStatements = parserFactory.createParser(scriptFile.get().asFile).parse()
+        val scriptStatements = scriptFiles.flatMap { parserFactory.createParser(it).parse() }
 
         // Clear the old and populate the new database
         val databaseFile = generatedDatabaseFile.get().asFile

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/DynamicFeatureProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/DynamicFeatureProjectSpec.kt
@@ -68,7 +68,7 @@ open class DynamicFeatureProjectSpec : BaseProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/JavaProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/JavaProjectSpec.kt
@@ -65,7 +65,7 @@ open class JavaProjectSpec : BaseProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/KotlinKaptProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/KotlinKaptProjectSpec.kt
@@ -68,7 +68,7 @@ open class KotlinKaptProjectSpec : KotlinProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/KotlinKspProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/KotlinKspProjectSpec.kt
@@ -67,7 +67,7 @@ open class KotlinKspProjectSpec : KotlinProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/NoSchemaLocationJavaProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/NoSchemaLocationJavaProjectSpec.kt
@@ -44,7 +44,7 @@ open class NoSchemaLocationJavaProjectSpec : JavaProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/NoSchemaLocationKotlinKaptProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/NoSchemaLocationKotlinKaptProjectSpec.kt
@@ -47,7 +47,7 @@ open class NoSchemaLocationKotlinKaptProjectSpec : KotlinKaptProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/NoSchemaLocationKotlinKspProjectSpec.kt
+++ b/prefiller/src/test/kotlin/io/github/simonschiller/prefiller/testutil/spec/NoSchemaLocationKotlinKspProjectSpec.kt
@@ -47,7 +47,7 @@ open class NoSchemaLocationKotlinKspProjectSpec : KotlinKspProjectSpec() {
         prefiller {
             database("people") {
                 classname.set("com.test.PeopleDatabase")
-                script.set(layout.projectDirectory.file("setup.sql"))
+                scripts.from(file("setup.sql"))
             }
         }
             

--- a/sample/java/build.gradle.kts
+++ b/sample/java/build.gradle.kts
@@ -57,10 +57,10 @@ dependencies {
 prefiller {
     database("customers") {
         classname.set("io.github.simonschiller.prefiller.sample.customer.CustomerDatabase")
-        script.set(layout.projectDirectory.file("../sql/customers.sql"))
+        scripts.from(file("../sql/customers.sql"))
     }
     database("products") {
         classname.set("io.github.simonschiller.prefiller.sample.product.ProductDatabase")
-        script.set(layout.projectDirectory.file("../sql/products.sql"))
+        scripts.from(file("../sql/orders.sql"), file("../sql/products.sql"))
     }
 }

--- a/sample/kotlin-kapt/build.gradle.kts
+++ b/sample/kotlin-kapt/build.gradle.kts
@@ -60,10 +60,10 @@ dependencies {
 prefiller {
     database("customers") {
         classname.set("io.github.simonschiller.prefiller.sample.customer.CustomerDatabase")
-        script.set(layout.projectDirectory.file("../sql/customers.sql"))
+        scripts.from(file("../sql/customers.sql"))
     }
     database("products") {
         classname.set("io.github.simonschiller.prefiller.sample.product.ProductDatabase")
-        script.set(layout.projectDirectory.file("../sql/products.sql"))
+        scripts.from(file("../sql/orders.sql"), file("../sql/products.sql"))
     }
 }

--- a/sample/kotlin-ksp/build.gradle.kts
+++ b/sample/kotlin-ksp/build.gradle.kts
@@ -58,10 +58,10 @@ dependencies {
 prefiller {
     database("customers") {
         classname.set("io.github.simonschiller.prefiller.sample.customer.CustomerDatabase")
-        script.set(layout.projectDirectory.file("../sql/customers.sql"))
+        scripts.from(file("../sql/customers.sql"))
     }
     database("products") {
         classname.set("io.github.simonschiller.prefiller.sample.product.ProductDatabase")
-        script.set(layout.projectDirectory.file("../sql/products.sql"))
+        scripts.from(file("../sql/orders.sql"), file("../sql/products.sql"))
     }
 }

--- a/sample/sql/orders.sql
+++ b/sample/sql/orders.sql
@@ -14,6 +14,6 @@
 -- limitations under the License.
 --
 
-INSERT INTO products(name, description) VALUES ("Thermosiphon", "Some description for the thermosiphon");
-INSERT INTO products(name, description) VALUES ("Pump", "Some description for the pump");
-INSERT INTO products(name, description) VALUES ("Heater", "Some description for the heater");
+INSERT INTO orders(description) VALUES ("Ketchup");
+INSERT INTO orders(description) VALUES ("Mustard");
+INSERT INTO orders(description) VALUES ("Mayonnaise");


### PR DESCRIPTION
Allows users to specify multiple script files per database, instead of limiting it to a single one (resolves #36).